### PR TITLE
update ssdmain to handle args

### DIFF
--- a/SSD/Nand.cpp
+++ b/SSD/Nand.cpp
@@ -35,7 +35,6 @@ map<int, string> Nand::LoadMapFromFile()
 	map<int, string> dataMap;
 
 	if (!file) {
-		cerr << "File could not be opened\n";
 		return dataMap;
 	}
 
@@ -65,7 +64,7 @@ void Nand::SaveMapToFile(map<int, string> data)
 	ofstream file(fileName, ios::binary | ios::trunc);
 
 	if (!file) {
-		cerr << "File could not be opened\n";
+		cerr << "Savefile failed: File could not be opened\n";
 		return;
 	}
 

--- a/SSD/main.cpp
+++ b/SSD/main.cpp
@@ -1,1 +1,42 @@
-int main(){}
+﻿#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include "ssd_factory.h"
+
+using namespace std;
+
+int main(int argc, char* argv[]) {
+    ISSDInterface* ssd = SSDFactory::CreateNandSSD();
+
+    if (argc < 3) {
+        std::cout << "Insufficient arguments" << std::endl;
+        return 1;
+    }
+
+    std::string operation = argv[1];
+    int address = std::stoi(argv[2]);
+
+    if (operation == "W") {
+        if (argc < 4) {
+            std::cout << "Insufficient arguments for write operation" << std::endl;
+            return 1;
+        }
+        std::string data = argv[3];
+        ssd->write(address, data);
+    }
+    else if (operation == "R") {
+        string data = ssd->read(address);
+        std::cout << "Read data: " << data << std::endl;
+        // write data to result.txt(always overwrite)
+		std::ofstream file("result.txt");
+		file << data;
+		file.close();
+    }
+    else {
+        std::cout << "Invalid operation" << std::endl;
+    }
+
+    delete ssd;
+    return 0;
+}


### PR DESCRIPTION
## SSD.exe로 실행할때 args처리 추가
## Test결과 참고부탁드립니다.
```
C:\Users\User\workspace\SSD\x64\Debug>SSD.exe W 1 0x22222222
Loadfile failed: File could not be opened

C:\Users\User\workspace\SSD\x64\Debug>SSD.exe R 1
Read data: 0x22222222

C:\Users\User\workspace\SSD\x64\Debug>SSD.exe W 1 0x21333333

C:\Users\User\workspace\SSD\x64\Debug>SSD.exe R 1
Read data: 0x21333333
```