### PR TITLE
.gitignore(coverage path) and TestShell.vcxproj(SSD.exe : Release version copy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ FodyWeavers.xsd
 
 # log path
 log/
+
+# coverage path
+coverage/

--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -130,6 +130,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PostBuildEvent>
+      <Command>"C:\Program Files\Git\usr\bin\cp.exe" $(TargetDir)SSD.exe .</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="run_list.lst" />


### PR DESCRIPTION
1. .gitignore(coverage path) 업데이트

2. TestShell.vcxproj(SSD.exe : Release version copy)
https://github.com/hshyune/SSD/pull/89  에서는 x64/Debug 만 설정 : 추가적으로 x64/Release 추가